### PR TITLE
fix(docs): use correct URLs for CDN example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ You can also import the esm bundle with unpkg:
 ```html
 <script type="module">
     // import a specific version
-    import * as p2 from 'https://www.unpkg.com/browse/p2-es@1.1.6/dist/p2-es.js';
+    import * as p2 from 'https://www.unpkg.com/p2-es@1.1.6/dist/p2-es.js';
 
     // or import latest
-    import * as p2 from 'https://www.unpkg.com/browse/p2-es/dist/p2-es.js';
+    import * as p2 from 'https://www.unpkg.com/p2-es/dist/p2-es.js';
 </script>
 ```
 ---


### PR DESCRIPTION
Looks like there's a typo in the CDN example. This was causing confusion in the threejs Discord server because it was blindly copied and pasted for testing.